### PR TITLE
修正概要: ASCシステムコールの数値->16進文字変換誤りを修正。

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -457,10 +457,10 @@ int sos_asc(void){
     int	c;
 
     c = (int)Z80_A & 0x0f;
-    if (c < 10){
-	Sethreg(Z80_AF, c);
+    if ( 10 > c ){
+	Sethreg(Z80_AF, c + '0');
     } else {
-	Sethreg(Z80_AF, c + 'A');
+	Sethreg(Z80_AF, (c - 10) + 'A');
     }
     return(TRAP_NEXT);
 }


### PR DESCRIPTION
ASCシステムコールの処理中の16進数値を16進数文字に変換する際に数値に'0'を足していなかった問題と0xaから0xfを変換する際に0xaを引いてから'A'を足すべきところを0xaを引かずに足していた問題とを修正。