### PR TITLE
修正概要: Macinto-Cなどの動作を実機に近づけるため, カーソル表示有効化時に仮想カーソルと物理カーソルが一致しない場合は, 両者を一致させるよう修正。

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -444,6 +444,10 @@ scr_visible(void){
 	return;
 
     scr_cur_visible = 1;
+
+    if (scr_vx != scr_px || scr_vy != scr_py)  /* sync cursor */
+	scr_pmove(scr_vy, scr_vx);
+
     if (scr_tc_ve_str == NULL)
 	return;
 


### PR DESCRIPTION
カーソル表示字に仮想カーソルと物理カーソルが一致しない問題を修正。
