### PR TITLE
XYADRワークスペース関連処理の追加

### DIFF
--- a/include/screen.h
+++ b/include/screen.h
@@ -11,6 +11,7 @@ void	scr_caps(int s);
 int	scr_initx(void);
 int	scr_finish(void);
 void	scr_redraw(void);
+void    scr_locate_cursor(int _y, int _x);
 
 void scr_putchar(char c);
 void scr_asyncputchar(char c);

--- a/include/sim-type.h
+++ b/include/sim-type.h
@@ -1,0 +1,36 @@
+/** z80 emulator type definition
+ */
+#ifndef	_SIM_TYPE_H
+#define	_SIM_TYPE_H
+
+#include <limits.h>
+
+#if UCHAR_MAX == 255
+typedef unsigned char	BYTE;
+#else
+#error Need to find an 8-bit type for BYTE
+#endif
+
+#if USHRT_MAX == 65535
+typedef unsigned short	WORD;
+#else
+#error Need to find an 16-bit type for WORD
+#endif
+
+/* FASTREG needs to be at least 16 bits wide and efficient for the
+   host architecture */
+#if UINT_MAX >= 65535
+typedef unsigned int	FASTREG;
+#else
+typedef unsigned long	FASTREG;
+#endif
+
+/* FASTWORK needs to be wider than 16 bits and efficient for the host
+   architecture */
+#if UINT_MAX > 65535
+typedef unsigned int	FASTWORK;
+#else
+typedef unsigned long	FASTWORK;
+#endif
+
+#endif  /*  _SIM_TYPE_H  */

--- a/include/trap.h
+++ b/include/trap.h
@@ -5,11 +5,18 @@
 #ifndef	_TRAP_H_
 #define	_TRAP_H_
 
+#include "sim-type.h"
+
 /*
    entry points
 */
 int trap(int func);
 int trap_init(void);
+
+BYTE trap_get_byte(WORD _addr);
+WORD trap_get_word(WORD _addr);
+void trap_put_byte(WORD _addr, BYTE _val);
+void trap_put_word(WORD _addr, WORD _val);
 
 /*
    return values from TRAP routine

--- a/include/trap.h
+++ b/include/trap.h
@@ -13,6 +13,8 @@
 int trap(int func);
 int trap_init(void);
 
+int write_work_space_without_sync(WORD _addr, BYTE _val);
+
 BYTE trap_get_byte(WORD _addr);
 WORD trap_get_word(WORD _addr);
 void trap_put_byte(WORD _addr, BYTE _val);

--- a/src/screen.c
+++ b/src/screen.c
@@ -445,15 +445,18 @@ scr_visible(void){
 
     scr_cur_visible = 1;
 
+    ON_CRITICAL;
+
     if (scr_vx != scr_px || scr_vy != scr_py)  /* sync cursor */
 	scr_pmove(scr_vy, scr_vx);
 
     if (scr_tc_ve_str == NULL)
-	return;
+	    goto end;
 
-    ON_CRITICAL;
     tputs(scr_tc_ve_str, 1, scr_pputchar);
     scr_term_fflush();
+
+end:
     OFF_CRITICAL;
 }
 

--- a/src/trap.c
+++ b/src/trap.c
@@ -217,6 +217,37 @@ char *trap_attr[] = {
 */
 BYTE	wkram[EM_WKSIZ+1];	/* S-OS special work */
 
+/** Detect writing to a workspace and sync behaviors according to a value in a workspace.
+    @param[in] addr an address to be written
+*/
+static void
+sync_work_space(WORD addr){
+	int x, y;
+	BYTE   v;
+
+	v = GetBYTE_INTERNAL(addr);  /* get current data */
+	scr_csr(&y, &x);  /* Get cursor for modifications of XYADR */
+	switch( addr ) {
+
+	case EM_XYADR:  /* Cursor X position */
+
+		/* locate cursor without writing to workspace. */
+		scr_locate_cursor(y, v);  /* update cursor */
+		break;
+
+	case (EM_XYADR + 1):  /* Cursor Y position */
+
+		/* locate cursor without writing to workspace. */
+		scr_locate_cursor(v, x);
+		break;
+
+	default:
+		break;
+	}
+
+	return ;
+}
+
 /*
    initialize trap handler & SWORD memory
 */
@@ -323,6 +354,7 @@ void
 trap_put_byte(WORD addr, BYTE val){
 
 	PutBYTE_INTERNAL(addr, val);
+	sync_work_space(addr);
 }
 
 /** Put a word data to RAM
@@ -333,6 +365,8 @@ void
 trap_put_word(WORD addr, WORD val){
 
 	PutWORD_INTERNAL(addr, val);
+	sync_work_space(addr);
+	sync_work_space(addr + 1);
 }
 
 /** Write to an address in work space for screen.c and trap.c.

--- a/src/trap.c
+++ b/src/trap.c
@@ -335,6 +335,30 @@ trap_put_word(WORD addr, WORD val){
 	PutWORD_INTERNAL(addr, val);
 }
 
+/** Write to an address in work space for screen.c and trap.c.
+    @param[in] addr an address to be written
+    @param[in] val  a value to write
+    @retval  0  success
+    @retval -1  the addr is not corresponding to any work space.
+*/
+int
+write_work_space_without_sync(WORD addr, BYTE val){
+	int x, y;
+
+	switch( addr ) {
+
+	case EM_XYADR:        /* Cursor X position */
+	case (EM_XYADR + 1):  /* Cursor Y position */
+		PutBYTE_INTERNAL(addr, val);
+		return 0;
+	default:
+		return -1;
+	}
+
+	return 0;
+}
+
+
 int sos_cold(void){
     Z80_PC = GetWORD(SOS_USR);
     return(TRAP_COLD);

--- a/src/trap.c
+++ b/src/trap.c
@@ -294,6 +294,47 @@ trap(int func){
     return r;
 }
 
+/** Get a byte data from an address in RAM
+    @param[in] addr an address to be written
+    @value     byte data
+ */
+BYTE
+trap_get_byte(WORD addr){
+
+	return GetBYTE_INTERNAL(addr);
+}
+/** Get a byte data from an address in RAM
+    @param[in] addr an address to be written
+    @value     byte data
+ */
+WORD
+trap_get_word(WORD addr){
+
+	return GetWORD_INTERNAL(addr);
+}
+
+
+/** Put a byte data to RAM
+    @param[in] addr an address to write to
+    @param[in] val  a byte data to be written
+    @value     byte data
+ */
+void
+trap_put_byte(WORD addr, BYTE val){
+
+	PutBYTE_INTERNAL(addr, val);
+}
+
+/** Put a word data to RAM
+    @param[in] addr an address to write to
+    @param[in] v    a word data to be written
+ */
+void
+trap_put_word(WORD addr, WORD val){
+
+	PutWORD_INTERNAL(addr, val);
+}
+
 int sos_cold(void){
     Z80_PC = GetWORD(SOS_USR);
     return(TRAP_COLD);


### PR DESCRIPTION
XYADRとカーソル動作を同期させることで, MACINTO-SなどのMACE上のカーソル操作アプリケーションを動作可能にした。

1. RAMへの書込を監視し, ワークスペースへの書込を検出
2. XYADRワークスペースへの書き込み時に指定された位置にカーソルを移動する処理を追加
3. カーソル移動時に移動後のカーソル座標をXYADRワークスペースへ書き込む処理を追加

