### PR TITLE
修正概要: pokeatの転送元/転送先アドレスの誤りを修正。

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -821,8 +821,8 @@ int sos_peeka(void){
     WORD	target;
     int		len;
 
-    offset = (int) Z80_HL;
-    target = Z80_DE;
+    target = Z80_HL;
+    offset = (int) Z80_DE;
     len = (int) Z80_BC;
 
     if (offset + len > EM_WKSIZ){


### PR DESCRIPTION
poke@システムコールの引数の解釈を誤っていた問題を修正。

誤:
* HL 特殊ワークエリア内のオフセットアドレス
* DE 転送先メモリアドレス

正:
* HL 転送先メモリアドレス
* DE 特殊ワークエリア内のオフセットアドレス

