### PR TITLE
修正概要: MZ/X1版の実装に合わせて, #LOCにスクリーン外の座標を指定した場合に, キャリーフラグを立ててエラー復帰するように修正。

### DIFF
--- a/include/trap.h
+++ b/include/trap.h
@@ -13,7 +13,7 @@
 int trap(int func);
 int trap_init(void);
 
-int write_work_space_without_sync(WORD _addr, BYTE _val);
+int write_workarea_without_sync(WORD _addr, BYTE _val);
 
 BYTE trap_get_byte(WORD _addr);
 WORD trap_get_word(WORD _addr);

--- a/src/screen.c
+++ b/src/screen.c
@@ -187,8 +187,8 @@ static void scr_delete(int _flag);
 static void
 sync_xyadr(int y, int x){
 
-	write_work_space_without_sync(EM_XYADR, x);
-	write_work_space_without_sync(EM_XYADR + 1, y);
+	write_workarea_without_sync(EM_XYADR, x);
+	write_workarea_without_sync(EM_XYADR + 1, y);
 }
 
 /*

--- a/src/trap.c
+++ b/src/trap.c
@@ -866,14 +866,31 @@ int sos_scrn(void){
 }
 
 int sos_loc(void){
-    scr_loc((int) Z80_H, (int) Z80_L);
+	int x,y;
 
-    /* #LOC shuld check validation of arguments and return
-       Carry Flag for error. (S-OS ref. man. p.118)
-       Currently not supported and only return with no carry */
-    SETFLAG(C, 0);
+	x = (int) Z80_L;
+	y = (int) Z80_H;
 
-    return(TRAP_NEXT);
+	if ( ( 0 > x ) ||
+	    ( x >= GetBYTE(SOS_WIDTH) ) ||
+	    ( 0 > y ) ||
+	    ( y >= GetBYTE(SOS_MAXLIN) ) ) {
+
+		/* #LOC shuld check validation of arguments and return
+		 * Carry Flag for error. (S-OS ref. man. p.118)
+		 */
+		SETFLAG(C, 1);  /* Invalid parameter */
+		goto out;
+	}
+
+	/*
+	 * locate cursor
+	 */
+	scr_loc(y, x);
+	SETFLAG(C, 0);  /* Success */
+
+out:
+	return(TRAP_NEXT);
 }
 
 int sos_flget(void){


### PR DESCRIPTION
MZやX1版のSwordでは, #LOCにスクリーン外の座標を指定した場合, キャリーフラグを立て, エラー復帰するようになっているため, UNIX版でも同様にエラーを返却できるように修正した。
