### PR TITLE
修正概要: #FLGETで制御コード(keymapで定義されたカーソルキーなど)が受け渡されない問題を修正。

### DIFF
--- a/include/screen.h
+++ b/include/screen.h
@@ -32,6 +32,25 @@ void scr_loc(int y, int x);
 int scr_flget(void);
 void scr_width(int x);
 
+/*
+ * keymap index
+ */
+#define SCR_KEYMAP_IDX_BACKSPACE  (0x00)
+#define SCR_KEYMAP_IDX_DELETE     (0x01)
+#define SCR_KEYMAP_IDX_BEGIN      (0x02)
+#define SCR_KEYMAP_IDX_END        (0x03)
+#define SCR_KEYMAP_IDX_UP         (0x04)
+#define SCR_KEYMAP_IDX_DOWN       (0x05)
+#define SCR_KEYMAP_IDX_FWD        (0x06)
+#define SCR_KEYMAP_IDX_BWD        (0x07)
+#define SCR_KEYMAP_IDX_REDRAW     (0x08)
+#define SCR_KEYMAP_IDX_KILL       (0x09)
+#define SCR_KEYMAP_IDX_TAB        (0x0a)
+#define SCR_KEYMAP_IDX_YANK       (0x0b)
+#define SCR_KEYMAP_IDX_IMODE      (0x0c)
+#define SCR_KEYMAP_IDX_CLEAR      (0x0d)
+#define SCR_KEYMAP_IDX_NULL       (0xff)
+
 /* key mapping functions */
 #define SCR_MAPERR_CODE	(1)
 #define	SCR_MAPERR_FUNC (2)

--- a/include/sos.h
+++ b/include/sos.h
@@ -10,6 +10,18 @@
 #endif  /*  __STDC__  */
 
 /*
+ * Sword control codes
+ */
+#define SCR_SOS_NUL     (0x0)   /* NUL code on S-OS */
+#define SCR_SOS_CLS     (0x0c)  /* CLS code on S-OS */
+#define SCR_SOS_CR      (0x0d)  /* CR code on S-OS */
+#define SCR_SOS_BREAK   (0x1b)  /* break key code on S-OS */
+#define SCR_SOS_RIGHT   (0x1c)  /* right cursor code on S-OS */
+#define SCR_SOS_LEFT    (0x1d)  /* left cursor code on S-OS */
+#define SCR_SOS_UP      (0x1e)  /* up cursor code on S-OS */
+#define SCR_SOS_DOWN    (0x1f)  /* down cursor code on S-OS */
+
+/*
    S-OS IOCS call in Z80 memory
    (only a part)
 */


### PR DESCRIPTION
FLGETで制御コード(keymapで定義されたカーソルキーなど)が受け渡されない問題を修正。
原因と修正内容は以下の通り。

## 原因(サマリ)

FLGETから呼び出される入力コード変換関数(scr_conv関数)に誤りがあった。

## 原因

scr_conv関数で, 端末から入力されたコントロールコードからSWORDに存在するコントロールコードに返却して入力コードを返却するべきところを変換していなかった。

キー入力関連システムコール(FLGET,INKEY,GETKY)の処理では, 内部で入力コード変換関数(scr_conv関数)を呼び出して入力文字コードをSWORDの文字コードに変換する。scr_conv関数では, ブレークキー以外の文字コードを変換していないため, FLGETなどのキー入力関連システムコール中でカーソルなどのコントロールコードがUNIXの端末から入力されたコードのまま返却されていたため, FLGETやINKEY, GETKYを使用するプログラム中でカーソルの押下を検出できていなかった。

## 修正内容(サマリ)

本修正では,FLGETから呼び出される入力コード変換関数(scr_conv関数)を修正する。

SWORDで規定されている全ての制御コードについて, 入力文字コードからSWORDの制御コードへ変換する処理を行うように入力コード変換関数(scr_conv関数)を修正し, ブレークキー以外の制御文字も正しく扱えるように修正する。

本修正に合わせて, FLGET,INKEY,GETKYを内部で使用している関数の処理についても見直し, GETLについて, GETFLから返されたSWORDの制御コードに応じて, キー関数テーブル(keyfuncs配列)に登録されている関数を呼び出すように修正する。

## 修正内容

以下の2つの変換テーブルを導入し,  UNIX端末からの入力コードから入力文字コードからSWORDの制御コードへ変換と
SWORDの制御コードからSWORDの制御コードに対応するキー関数に対するキー関数テーブル(keyfuncs配列)のインデクスへの変換, SWORDの制御コードに対応するキー関数に対するキー関数の呼び出しを行う。

* scr_keyfunc_idx2sword キー関数テーブル(keyfuncs配列)のインデクスからSWORDの制御コードへ変換するテーブル, これを用いて, UNIX端末からの入力コード中でキーマップの定義に応じて変換元のUNIX端末からの入力コードをSWORDの制御コードへ変換する。
* sword2keyfunc_idx SWORDの制御コードに対応するキー関数テーブル(keyfuncs配列)のインデクスを返却する

なお、ブレークコードについては従来通り(ブレークコードのキーコードに対応する入力コードである)ESC(0x1b)に加えCtrl-C(0x03)をSWORDのブレークコードに変換する処理を入力コード変換関数(scr_conv関数)内で実施する。

入力された制御コードの内, SWORDの仕様内に定義されていない制御コードは, 従来通り入力コードからキー関数テーブル(keyfuncs配列)に登録されている処理を検索することで実施する。

キー関数テーブル(screen.c内のkeyfuncs配列)内に登録されている操作の内, SWORD仕様で定義されている制御文字は, 以下の5つである。

|文字コード種別|デフォルトキーマップでの入力コード|SWORDでの文字コード|キー関数テーブル(screen.c内のkeyfuncs配列)のインデクス番号|
|---|---|---|---|
|上カーソルキー|Ctrl-P(0x10)|0x1E|0x04|
|下カーソルキー|Ctrl-N(0x0E)|0x1F|0x05|
|右カーソルキー|Ctrl-F(0x06)|0x1C|0x06|
|左カーソルキー|Ctrl-B(0x02)|0x1D|0x07|
|画面クリア|Ctrl-Q(0x11)|0x0C|0x0d|
