### PR TITLE
修正概要: 配列インデクスを格納した配列の型をintとするべきところをcharにしていた問題を修正。

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -197,7 +197,7 @@ static char scr_keyfunc_idx2sword[]={
  * convert table to convert from a ctrl code in SWORD to a keyfunc index.
  * SCR_KEYMAP_IDX_NULL(0xff) means no entry exits in keyfunc index.
  */
-static char sword2keyfunc_idx[]={
+static int sword2keyfunc_idx[]={
 	SCR_KEYMAP_IDX_NULL,  /* 0x00 (NUL)  */
 	SCR_KEYMAP_IDX_NULL,  /* 0x01        */
 	SCR_KEYMAP_IDX_NULL,  /* 0x02        */


### PR DESCRIPTION
キーマップに定義されたSwordに規定されていない制御文字が処理されなくなっていた問題を修正。
配列インデクスを格納した配列の型をintとするべきところをcharにしていたことが原因。