### PR TITLE
FCBシステムコールをSwordのDOSモジュールに依存せず実行可能にした

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,8 +1,17 @@
 TODO list
 
-�EDOS �����̃��C�Z���X�̃N���A
-�E���A���^�C�����͂̉���
-�EBYTE,char,unsigned char �֌W�̃R�[�h�̐���
-�E�������Y��ȃL�[�J�X�^�}�C�Y
-�E�g���Z�b�g�̋@�\�̓���
-�E���z��ʊǗ����Ǝ���ʐ��䕔�̕���
+楯岡さんTODO
+
+・DOS 部分のライセンスのクリア
+・リアルタイム入力の改良
+・BYTE,char,unsigned char 関係のコードの整理
+・もっと綺麗なキーカスタマイズ
+・拡張セットの機能の導入
+・仮想画面管理部と実画面制御部の分離
+
+(*) DOS 部分のライセンスのクリアについては,
+加藤TODO
+・zedaでQ:のファイルを読めない原因の調査.
+・垂直同期の時間間隔の計測
+・クロックティックに応じてCPUの命令を処理
+・D88フォーマット対応

--- a/include/dio.h
+++ b/include/dio.h
@@ -8,6 +8,7 @@
 #ifndef	_DIO_H_
 #define	_DIO_H_
 
+#include "sim-type.h"
 #include "sos.h"
 
 /* raw I/O */
@@ -25,4 +26,51 @@ int dio_rdd(unsigned char *buf, int len);
 /* disk image file name */
 extern char	*dio_disk[SOS_MAXIMAGEDRIVES];
 
+#define SOS_TAPE_COMMON_IDX   (0)  /* Common MZ format tape */
+#define SOS_TAPE_MONITOR_IDX  (1)  /* Monitor specific format tape */
+#define SOS_TAPE_QD_IDX       (2)  /* Quick disk */
+#define SOS_TAPE_NR           (3)  /* The number of tape devices */
+
+/** Determine whether device is a disk.
+    @param[in] _dsk drive letter to be checked.
+ */
+#define sos_device_is_disk(_dsk)			\
+	( ( SOS_DL_RESV_MAX >= (_dsk) ) && ( (_dsk) >= SOS_DL_DRIVE_A ) )
+
+/** Determine whether device is standard disks.
+    @param[in] _dsk drive letter to be checked.
+ */
+#define sos_device_is_standard_disk(_dsk)		\
+	( ( SOS_DL_DRIVE_D >= (_dsk) ) && ( (_dsk) >= SOS_DL_DRIVE_A ) )
+
+/** Determine whether device is a tape.
+    @param[in] _dsk drive letter to be checked.
+ */
+#define sos_device_is_tape(_dsk)					\
+	( ( (_dsk) == SOS_DL_COM_CMT ) ||				\
+	    ( (_dsk) == SOS_DL_MON_CMT ) ||				\
+	    ( (_dsk) == SOS_DL_QD ) )
+
+/** convert a device letter to an index of sos_tape_device_info array.
+    @param[in] _dsk drive letter
+    @return an index of sos_tape_device_info array
+ */
+#define sos_tape_devindex(_dsk) 			\
+	( (_dsk) == SOS_DL_COM_CMT ? SOS_TAPE_COMMON_IDX :		\
+	    ( (_dsk) == SOS_DL_MON_CMT ? SOS_TAPE_MONITOR_IDX : SOS_TAPE_QD_IDX ) )
+
+/** convert an index of sos_tape_device_info array to a device letter.
+    @param[in] index of sos_tape_device_info array
+    @return drive letter
+ */
+#define sos_tape_device_letter(_idx) 				\
+	( (_idx) == SOS_TAPE_COMMON_IDX ? SOS_DL_COM_CMT :	\
+	    ( (_idx) == SOS_TAPE_MONITOR_IDX ? SOS_DL_MON_CMT : SOS_DL_QD ) )
+
+/* Tape device emulation */
+typedef struct _sos_tape_device_info{
+	BYTE    dsk;  /**< device letter */
+	BYTE  dirno;  /**< #DIRNO of the device */
+	BYTE retpoi; /**< RETPOI of the device */
+}sos_tape_device_info;
 #endif

--- a/include/sos.h
+++ b/include/sos.h
@@ -123,14 +123,37 @@
 #endif /* PATH_MAX */
 
 /*
+ * Drive letters
+ */
+#define SOS_DL_DRIVE_A   'A'
+#define SOS_DL_DRIVE_B   'B'
+#define SOS_DL_DRIVE_C   'C'
+#define SOS_DL_DRIVE_D   'D'
+#define SOS_DL_RESV_MIN  'E'
+#define SOS_DL_RESV_MAX  'L'
+#define SOS_DL_COM_CMT   'T'
+#define SOS_DL_MON_CMT   'S'
+#define SOS_DL_QD        'Q'
+
+/*
+ * SOS File Information Block/Directory Entry offset addresses in EM_IBFAD
+ */
+#define SOS_FIB_OFF_ATTR  (0)   /**< File Attribute */
+#define SOS_FIB_OFF_FNAME (1)   /**< File Name      */
+#define SOS_FIB_OFF_SIZE  (18)  /**< File Size      */
+#define SOS_FIB_OFF_DTADR (20)  /**< Data Addr      */
+#define SOS_FIB_OFF_EXADR (22)  /**< File Size      */
+/*
    Emulator setting
 */
 #define	EM_XYADR	(0x1171)
 #define	EM_KBFAD	(0x11a3)
 #define	EM_IBFAD	(0x10f0)
-#define	EM_SIZE		(0x1102)
-#define	EM_DTADR	(0x1104)
-#define	EM_EXADR	(0x1106)
+#define	EM_ATTR		(EM_IBFAD + SOS_FIB_OFF_ATTR)  /* 0x10f0 */
+#define	EM_FNAME	(EM_IBFAD + SOS_FIB_OFF_FNAME) /* 0x10f1 */
+#define	EM_SIZE		(EM_IBFAD + SOS_FIB_OFF_SIZE)  /* 0x1102 */
+#define	EM_DTADR	(EM_IBFAD + SOS_FIB_OFF_DTADR) /* 0x1104 */
+#define	EM_EXADR	(EM_IBFAD + SOS_FIB_OFF_EXADR) /* 0x1106 */
 #define	EM_STKAD	(0x10f0)
 #define	EM_MEMAX	(0xffff)
 #define	EM_WKSIZ	(0xffff)
@@ -142,7 +165,7 @@
 #define	EM_WIDTH	(0x50)
 #define	EM_MAXLN	(25)
 
-#define	EM_DFDV		('Q')
+#define	EM_DFDV		(SOS_DL_QD)
 
 #define	EM_VER		(0x1620)	/* XXX: SWORD version */
 

--- a/include/sos.h
+++ b/include/sos.h
@@ -22,6 +22,39 @@
 #define SCR_SOS_DOWN    (0x1f)  /* down cursor code on S-OS */
 
 /*
+ * Error codes
+ */
+#define SOS_ERROR_SUCCESS     (0x0)  /* success */
+#define SOS_ERROR_IO          (0x1)  /* Device I/O Error */
+#define SOS_ERROR_OFFLINE     (0x2)  /* Device Offline */
+#define SOS_ERROR_BADF        (0x3)  /* Bad File Descriptor */
+#define SOS_ERROR_RDONLY      (0x4)  /* Write Protected */
+#define SOS_ERROR_BADR        (0x5)  /* Bad Record */
+#define SOS_ERROR_FMODE       (0x6)  /* Bad File Mode */
+#define SOS_ERROR_BADFAT      (0x7)  /* Bad Allocation Table */
+#define SOS_ERROR_NOENT       (0x8)  /* File not Found */
+#define SOS_ERROR_NOSPC       (0x9)  /* Device Full */
+#define SOS_ERROR_EXIST       (0xa)  /* File Already Exists */
+#define SOS_ERROR_RESERVED    (0xb)  /* Reserved Feature */
+#define SOS_ERROR_NOTOPEN     (0xc)  /* File not Open */
+#define SOS_ERROR_SYNTAX      (0xd)  /* Syntax Error */
+#define SOS_ERROR_INVAL       (0xe)  /* Bad Data */
+#define SOS_ERROR_NR          (0xf)  /* The number of error numbers */
+
+/*
+ * File attributes
+ */
+#define SOS_FATTR_FREE    (0x0)   /* Free entry */
+#define SOS_FATTR_BIN     (0x1)   /* Binary */
+#define SOS_FATTR_BAS     (0x2)   /* Basic  */
+#define SOS_FATTR_ASC     (0x4)   /* Ascii  */
+#define SOS_FATTR_RSV     (0x8)   /* Reserved */
+#define SOS_FATTR_HIDDEN  (0x10)  /* Hidden file */
+#define SOS_FATTR_RAW     (0x20)  /* Read after write */
+#define SOS_FATTR_RONLY   (0x40)  /* Read only */
+#define SOS_FATTR_DIR     (0x80)  /* Sub directory */
+#define SOS_FATTR_EODENT  (0xFF)  /* End of directory entry */
+/*
    S-OS IOCS call in Z80 memory
    (only a part)
 */
@@ -56,10 +89,16 @@
 #define	SOS_WIDTH (0x1f5c)
 #define	SOS_MAXLIN (0x1f5b)
 
-#define	SOS_FTYPE	(0x291f)
-#define	SOS_DFDV	(0x2920)
+#define SOS_RETPOI      (0x2418)
+#define SOS_OPNFG       (0x291e)
+#define SOS_FTYPE       (0x291f)
+#define SOS_DFDV        (0x2920)
 
 #define	SOS_UNITNO	(0x2b06)
+
+#define SOS_DVSW_COMMON    (0)
+#define SOS_DVSW_MONITOR   (1)
+#define SOS_DVSW_QD        (3)
 
 #define SOS_FNAMENAMELEN	(13)
 #define	SOS_FNAMEEXTLEN		(3)
@@ -70,11 +109,19 @@
 #define CCP_LINLIM              (2000)
 #define SOS_UNIX_BUFSIZ         (2000)
 #define TRAP_BUFSIZ             (80)
+
+#define SOS_RECORD_SIZE         (256) /* Record (Sector) size in byte. */
+#define SOS_DENTRY_SIZE         (32)  /* Directory entry size in byte . */
+#define SOS_DENTRIES_PER_REC    \
+	( SOS_RECORD_SIZE / SOS_DENTRY_SIZE ) /* 8 file entries. */
+
+
 #if defined(PATH_MAX)
 #define SOS_UNIX_PATH_MAX       (PATH_MAX)
 #else
 #define SOS_UNIX_PATH_MAX       (1024)
 #endif /* PATH_MAX */
+
 /*
    Emulator setting
 */

--- a/include/trap.h
+++ b/include/trap.h
@@ -13,13 +13,12 @@
 int trap(int func);
 int trap_init(void);
 
-int write_workarea_without_sync(WORD _addr, BYTE _val);
-
 BYTE trap_get_byte(WORD _addr);
 WORD trap_get_word(WORD _addr);
 void trap_put_byte(WORD _addr, BYTE _val);
 void trap_put_word(WORD _addr, WORD _val);
-
+int trap_write_workarea_without_sync(WORD _addr, BYTE _val);
+void trap_change_tape(char _dev);
 /*
    return values from TRAP routine
 */

--- a/src/screen.c
+++ b/src/screen.c
@@ -290,8 +290,8 @@ static void scr_delete(int _flag);
 static void
 sync_xyadr(int y, int x){
 
-	write_workarea_without_sync(EM_XYADR, x);
-	write_workarea_without_sync(EM_XYADR + 1, y);
+	trap_write_workarea_without_sync(EM_XYADR, x);
+	trap_write_workarea_without_sync(EM_XYADR + 1, y);
 }
 
 /*


### PR DESCRIPTION
FCBシステムコールをSwordのDOSモジュールに依存せず実行可能にした。

修正内容は以下の通り:

* sos_fcb()関数を新設し, FCBシステムコール呼び出し時に実行されるようにした。
* sos_rdi()関数内で#DIRNOワークエリアを更新して居なかった問題を修正した。
* 実際のテープデバイスの場合, シーケンシャルアクセスになることから, DIRNOワークエリアの値によらず前回読み込んだファイル情報ブロック(FIB)の次のFIBから読み込まれるため, テープデバイス単位で前回読み込んだファイル情報ブロックの位置(DIRNOワークエリアに相当する値)を各テープデバイス毎に保存し, RDIシステムコール処理時に最後に読み込んだFIBの次のブロックから読み込まれるようにした。
* モニタから(cd, chdirコマンドにより)ディレクトリを移動した際にドライブ'Q'の読み取り開始ファイル情報ブロック(内部ワークエリアRETPOI),  次のの位置(DIRNOワークエリアに相当する値)をクリアするようにした
* SwordのFCBの動作にあわせ, FCB/RDIでブレークを入力した場合, DIRNOワークエリアの値をデクリメントし, 内部ワークエリアRETPOIを先頭に戻す処理を追加した

