### PR TITLE
修正概要: ディレクトリ変更時にホストファイル('Q')の#DIRNOをリセットする処理を組込み。

### DIFF
--- a/src/sos.c
+++ b/src/sos.c
@@ -103,7 +103,8 @@ ccpline(char *p, int mode){
 	    if (chdir(np)){
 		    snprintf(lbuf, CCP_LINLIM, "%s: %s\r", np, strerror(errno));
 		scr_puts(lbuf);
-	    }
+	    } else
+		    trap_change_tape(SOS_DL_QD);  /* Reset #DIRNO and RETPOI */
 	}
 	if (getcwd(lbuf, sizeof(lbuf)) != NULL){
 	    scr_puts(lbuf);


### PR DESCRIPTION
ディレクトリ変更時にホストファイル('Q')の#DIRNOをリセットする処理を機種固有モニタに組込んだ。