### PR TITLE
FSAME, RDIの処理を見直し, zedaを動作可能にした。

### DIFF
--- a/include/sos.h
+++ b/include/sos.h
@@ -50,10 +50,11 @@
 #define SOS_FATTR_ASC     (0x4)   /* Ascii  */
 #define SOS_FATTR_RSV     (0x8)   /* Reserved */
 #define SOS_FATTR_HIDDEN  (0x10)  /* Hidden file */
-#define SOS_FATTR_RAW     (0x20)  /* Read after write */
+#define SOS_FATTR_RAW     (0x20)  /* Read after write (RAW) */
 #define SOS_FATTR_RONLY   (0x40)  /* Read only */
 #define SOS_FATTR_DIR     (0x80)  /* Sub directory */
 #define SOS_FATTR_EODENT  (0xFF)  /* End of directory entry */
+#define SOS_FATTR_MASK    (0x87)  /* File type mask and clear Hidden/RAW/ReadOnly bits */
 /*
    S-OS IOCS call in Z80 memory
    (only a part)
@@ -100,10 +101,12 @@
 #define SOS_DVSW_MONITOR   (1)
 #define SOS_DVSW_QD        (3)
 
+#define SOS_DRIVE_LETTER_LEN    (2)
 #define SOS_FNAMENAMELEN	(13)
 #define	SOS_FNAMEEXTLEN		(3)
 #define	SOS_FNAMELEN	        (SOS_FNAMENAMELEN + SOS_FNAMEEXTLEN)
-#define SOS_DIRFMTLEN           (SOS_FNAMELEN + 24)
+#define SOS_FNAMEBUF_SIZE       ( SOS_DRIVE_LETTER_LEN + SOS_FNAMELEN + 1)
+#define SOS_DIRFMTLEN           (SOS_FNAMELEN + 26)
 #define	SOS_MAXIMAGEDRIVES	(4)
 
 #define CCP_LINLIM              (2000)
@@ -143,6 +146,7 @@
 #define SOS_FIB_OFF_SIZE  (18)  /**< File Size      */
 #define SOS_FIB_OFF_DTADR (20)  /**< Data Addr      */
 #define SOS_FIB_OFF_EXADR (22)  /**< File Size      */
+#define SOS_EM_OWA_OFF    (24)  /**< Other Internal workarea starts from here */
 /*
    Emulator setting
 */
@@ -154,6 +158,8 @@
 #define	EM_SIZE		(EM_IBFAD + SOS_FIB_OFF_SIZE)  /* 0x1102 */
 #define	EM_DTADR	(EM_IBFAD + SOS_FIB_OFF_DTADR) /* 0x1104 */
 #define	EM_EXADR	(EM_IBFAD + SOS_FIB_OFF_EXADR) /* 0x1106 */
+#define EM_NAMEBF       (EM_IBFAD + SOS_EM_OWA_OFF)    /* 0x1108 */
+#define EM_NAMEBF_LEN   (18)                           /* NAMEBF in Sword */
 #define	EM_STKAD	(0x10f0)
 #define	EM_MEMAX	(0xffff)
 #define	EM_WKSIZ	(0xffff)

--- a/src/trap.c
+++ b/src/trap.c
@@ -1319,6 +1319,8 @@ int sos_rdi(void){
     sos_parsc();            /* Set #SIZE, #DTADR, #EXADR up */
     PutBYTE(SOS_OPNFG, 1);  /* open file */
 
+    sos_tropn();            /* open the file */
+
     inf->dirno = GetBYTE(SOS_DIRNO) + 1; /* Inc DIRNO of the device */
     if ( inf->dirno == 0xff )
 	    goto file_not_found; /* UCHAR_MAX reached */

--- a/src/trap.c
+++ b/src/trap.c
@@ -216,7 +216,7 @@ char *trap_attr[] = {
 /*
    variables
 */
-BYTE	wkram[EM_WKSIZ+1];	/* S-OS special work */
+static BYTE	wkram[EM_WKSIZ+1];	/* S-OS special work */
 static sos_tape_device_info tapes[SOS_TAPE_NR];  /* tape devices */
 
 /** Initialize tape device emulation
@@ -796,13 +796,13 @@ trap_fname(unsigned char *buf, unsigned char *dsk, unsigned char defdsk){
     /* get file name */
     while(ram[ri] == ' ')		/* space skip */
 	ri++;
-    for (len=0; len<13; len++){
+    for (len=0; len<SOS_FNAMENAMELEN; len++){
 	if ((c = ram[ri]) < ' ' || c == ':' || c == '.')
 	    break;
 	*buf++ = c;
 	ri++;
     }
-    for (; len<13; len++)
+    for (; len<SOS_FNAMENAMELEN; len++)
 	*buf++ = ' ';			/* space padding */
 
     /* skip "." of extension */
@@ -810,13 +810,13 @@ trap_fname(unsigned char *buf, unsigned char *dsk, unsigned char defdsk){
 	ri++;
 
     /* get extention */
-    for (len=0; len<3; len++){
+    for (len=0; len<SOS_FNAMEEXTLEN; len++){
 	if ((c = ram[ri]) < ' ' || c == ':')
 	    break;
 	*buf++ = c;
 	ri++;
     }
-    for (; len<3; len++)
+    for (; len<SOS_FNAMEEXTLEN; len++)
 	*buf++ = ' ';			/* space padding */
 
     *buf = '\0';
@@ -828,7 +828,7 @@ trap_fname(unsigned char *buf, unsigned char *dsk, unsigned char defdsk){
 int sos_file(void){
     WORD	wi;
     BYTE	attr;
-    unsigned char	buf[SOS_FNAMELEN + 1];
+    unsigned char	buf[SOS_FNAMEBUF_SIZE];
     unsigned char	dsk;
     int		r;
 
@@ -847,6 +847,7 @@ int sos_file(void){
 	return(TRAP_NEXT);
     }
     memcpy(ram + wi, buf, SOS_FNAMELEN);
+    memcpy(ram + EM_NAMEBF, buf, SOS_FNAMELEN);
     PutBYTE(SOS_DSK, dsk);
 
     SETFLAG(C, 0);
@@ -854,36 +855,66 @@ int sos_file(void){
 }
 
 int sos_fsame(void){
-    unsigned char	buf[SOS_FNAMELEN + 1];
+    unsigned char	buf[SOS_FNAMEBUF_SIZE];
     unsigned char	dsk;
+    WORD           saved_de;
     int	r;
 
     /* check attribute */
-    if (GetBYTE(EM_IBFAD) != Z80_A){
-	SETFLAG(Z, 0);
-	return(TRAP_NEXT);
+    if ( ( GetBYTE(EM_IBFAD) & SOS_FATTR_MASK ) != ( Z80_A & SOS_FATTR_MASK ) ) {
+
+	    SETFLAG(Z, 0);
+	    return(TRAP_NEXT);
     }
 
+    /*
+     * check the buffer pointed by DE register
+     */
+    saved_de = Z80_DE;
+
+    /* pass file name which is read by FILE */
+    Z80_DE = EM_NAMEBF;
     /* parse file name */
-    if (r = trap_fname(buf, &dsk, GetBYTE(SOS_DSK))){
-	Sethreg(Z80_AF, r);
-	SETFLAG(C, 1);
-	return(TRAP_NEXT);
+    r = trap_fname(buf, &dsk, GetBYTE(SOS_DSK));
+    Z80_DE = saved_de; /* restore DE */
+    if ( r != 0 )
+	    goto compare_with_de;
+
+    /* compare them */
+    if (memcmp(buf, ram + EM_IBFAD + 1, SOS_FNAMELEN) == 0){
+	    SETFLAG(Z, 1);
+	    goto out;
+    } else {
+	    SETFLAG(Z, 0);
+    }
+
+    /*
+     * Compare with DE register (MACE)
+     */
+compare_with_de:
+    r = trap_fname(buf, &dsk, GetBYTE(SOS_DSK));
+    if ( r != 0 ){
+
+	    Sethreg(Z80_AF, r);
+	    SETFLAG(C, 1);
+	    return(TRAP_NEXT);
     }
 
     /* compare them */
     if (memcmp(buf, ram + EM_IBFAD + 1, SOS_FNAMELEN) == 0){
-	SETFLAG(Z, 1);
+	    SETFLAG(Z, 1);
     } else {
-	SETFLAG(Z, 0);
+	    SETFLAG(Z, 0);
     }
+
+out:
     SETFLAG(C, 0);
     return(TRAP_NEXT);
 }
 
 int sos_fprnt(void){
     WORD	namep;
-    char	buf[SOS_FNAMELEN+2], *p;
+    char	buf[SOS_FNAMEBUF_SIZE+1], *p;
     int		i;
     int	c;
 
@@ -1354,7 +1385,7 @@ int sos_trdd(void){
 
 int sos_tdir(void){
     int	dirno;
-    char	name[SOS_FNAMELEN + 1];
+    char	name[SOS_FNAMEBUF_SIZE];
     char	ext[SOS_FNAMEEXTLEN + 1];
     int	        len, attr, addr, exaddr;
     char	buf[SOS_DIRFMTLEN + 1];


### PR DESCRIPTION
1. SwordのFSAMEの名前比較手順とMACEの名前比較手順の双方に対応

* SWORDの場合 FILEで読み込んだ名前をNAMEBFというワークエリアに保存し, FSAMEでNAMEBFの内容とファイル情報ブロック内の名前とを比較する
* MACEの場合    DEレジスタで指定した文字列とファイル情報ブロック内の名前とを比較する

2. RDI成功時にROPENを実施し, 後続のRDDでファイルの読み込みを可能にした

上記修正により, ZEDAが動作することを確認した。