### PR TITLE
ブレークキーの定義をキーマップで変更可能にした。

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -25,6 +25,26 @@
 #define KEYMAP_NAME_BREAK     "break"
 
 /*
+ * keymap index
+ */
+#define SCR_KEYMAP_IDX_BACKSPACE  (0x00)
+#define SCR_KEYMAP_IDX_DELETE     (0x01)
+#define SCR_KEYMAP_IDX_BEGIN      (0x02)
+#define SCR_KEYMAP_IDX_END        (0x03)
+#define SCR_KEYMAP_IDX_UP         (0x04)
+#define SCR_KEYMAP_IDX_DOWN       (0x05)
+#define SCR_KEYMAP_IDX_FWD        (0x06)
+#define SCR_KEYMAP_IDX_BWD        (0x07)
+#define SCR_KEYMAP_IDX_REDRAW     (0x08)
+#define SCR_KEYMAP_IDX_KILL       (0x09)
+#define SCR_KEYMAP_IDX_TAB        (0x0a)
+#define SCR_KEYMAP_IDX_YANK       (0x0b)
+#define SCR_KEYMAP_IDX_IMODE      (0x0c)
+#define SCR_KEYMAP_IDX_CLEAR      (0x0d)
+#define SCR_KEYMAP_IDX_BREAK      (0x0e)
+#define SCR_KEYMAP_IDX_NULL       (0xff)
+
+/*
  * proto types
  */
 void setdefaultkeymap(void);

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -1,4 +1,31 @@
+/*
+   SWORD Emulator keymap header
+*/
+
 #ifndef _KEYMAP_H_
 #define _KEYMAP_H_
+
+/*
+ * keymap search key strings
+ */
+#define KEYMAP_NAME_BACKSPACE "backspace"
+#define KEYMAP_NAME_DELETE    "delete"
+#define KEYMAP_NAME_BEGIN     "begin"
+#define KEYMAP_NAME_END       "end"
+#define KEYMAP_NAME_UP        "up"
+#define KEYMAP_NAME_DOWN      "down"
+#define KEYMAP_NAME_FWD       "forward"
+#define KEYMAP_NAME_BACK      "back"
+#define KEYMAP_NAME_REDRAW    "redraw"
+#define KEYMAP_NAME_KILL      "kill"
+#define KEYMAP_NAME_TAB       "tab"
+#define KEYMAP_NAME_YANK      "yank"
+#define KEYMAP_NAME_IMODE     "imode"
+#define KEYMAP_NAME_CLEAR     "clear"
+#define KEYMAP_NAME_BREAK     "break"
+
+/*
+ * proto types
+ */
 void setdefaultkeymap(void);
-#endif
+#endif  /*  _KEYMAP_H_  */

--- a/include/screen.h
+++ b/include/screen.h
@@ -32,25 +32,6 @@ void scr_loc(int y, int x);
 int scr_flget(void);
 void scr_width(int x);
 
-/*
- * keymap index
- */
-#define SCR_KEYMAP_IDX_BACKSPACE  (0x00)
-#define SCR_KEYMAP_IDX_DELETE     (0x01)
-#define SCR_KEYMAP_IDX_BEGIN      (0x02)
-#define SCR_KEYMAP_IDX_END        (0x03)
-#define SCR_KEYMAP_IDX_UP         (0x04)
-#define SCR_KEYMAP_IDX_DOWN       (0x05)
-#define SCR_KEYMAP_IDX_FWD        (0x06)
-#define SCR_KEYMAP_IDX_BWD        (0x07)
-#define SCR_KEYMAP_IDX_REDRAW     (0x08)
-#define SCR_KEYMAP_IDX_KILL       (0x09)
-#define SCR_KEYMAP_IDX_TAB        (0x0a)
-#define SCR_KEYMAP_IDX_YANK       (0x0b)
-#define SCR_KEYMAP_IDX_IMODE      (0x0c)
-#define SCR_KEYMAP_IDX_CLEAR      (0x0d)
-#define SCR_KEYMAP_IDX_NULL       (0xff)
-
 /* key mapping functions */
 #define SCR_MAPERR_CODE	(1)
 #define	SCR_MAPERR_FUNC (2)

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -1,3 +1,7 @@
+/*
+   SWORD Emulator keymap module
+   tate@spa.is.uec.ac.jp
+*/
 
 #include "config.h"
 
@@ -15,33 +19,35 @@ static struct map {
     char *funcname;
 } defaultmap[] = {
 #ifdef OPT_KEYMAP_WM
-    {'S', "back"},
-    {'D', "forward"},
-    {'E', "up"},
-    {'X', "down"},
-    {'J', "redraw"},
-    {'G', "delete"},
-    {'B', "backspace"},
-    {'I', "tab"},
-    {'H', "backspace"},
-    {'O', "imode"},
-    {'Q', "clear"},
+    {'S', KEYMAP_NAME_BACK},
+    {'D', KEYMAP_NAME_FWD},
+    {'E', KEYMAP_NAME_UP},
+    {'X', KEYMAP_NAME_DOWN},
+    {'J', KEYMAP_NAME_REDRAW},
+    {'G', KEYMAP_NAME_DELETE},
+    {'B', KEYMAP_NAME_BACKSPACE},
+    {'I', KEYMAP_NAME_TAB},
+    {'H', KEYMAP_NAME_BACKSPACE},
+    {'O', KEYMAP_NAME_IMODE},
+    {'Q', KEYMAP_NAME_CLEAR},
+    {'C', KEYMAP_NAME_BREAK},
     {'\0', NULL}
 #else
-    {'H', "backspace"},
-    {'D', "delete"},
-    {'A', "begin"},
-    {'E', "end"},
-    {'P', "up"},
-    {'N', "down"},
-    {'F', "forward"},
-    {'B', "back"},
-    {'L', "redraw"},
-    {'K', "kill"},
-    {'I', "tab"},
-    {'Y', "yank"},
-    {'O', "imode"},
-    {'Q', "clear"},
+    {'H', KEYMAP_NAME_BACKSPACE},
+    {'D', KEYMAP_NAME_DELETE},
+    {'A', KEYMAP_NAME_BEGIN},
+    {'E', KEYMAP_NAME_END},
+    {'P', KEYMAP_NAME_UP},
+    {'N', KEYMAP_NAME_DOWN},
+    {'F', KEYMAP_NAME_FWD},
+    {'B', KEYMAP_NAME_BACK},
+    {'L', KEYMAP_NAME_REDRAW},
+    {'K', KEYMAP_NAME_KILL},
+    {'I', KEYMAP_NAME_TAB},
+    {'Y', KEYMAP_NAME_YANK},
+    {'O', KEYMAP_NAME_IMODE},
+    {'Q', KEYMAP_NAME_CLEAR},
+    {'C', KEYMAP_NAME_BREAK},
     {'\0', NULL}
 #endif
 };

--- a/src/screen.c
+++ b/src/screen.c
@@ -1281,22 +1281,17 @@ scr_conv(char oc){
 	/* some system thinks char as signed char */
 	c = ((unsigned char) oc) & 0xff;
 
-	if ( ( 0 > c ) || ( c >= ' ' ) )
+	/*
+	 * When c is not control code or the keymap does not need to convert,
+	 * skip convert character.
+	 */
+	if ( ( 0 > c ) || ( c >= ' ' ) || ( 0 > keymap[c] ) )
 		goto skip_conv;
 
-	/*
-	 * Ctrl code
-	 */
-	if ( c == ( 'C'-'@' ) )
-		c = SCR_SOS_BREAK; /* C-c maps to SOS Break code */
-	else if ( ( keymap[c] >= SCR_KEYMAP_IDX_UP )
-	    && ( SCR_KEYMAP_IDX_BWD >= keymap[c] ) ) {
-
-		/*
-		 * Convert cursor keys
-		 */
+	/* Convert a control code on UNIX to a control code on Sword. */
+	if ( keyfuncs[keymap[c]].ch_on_sos != SCR_SOS_NUL )
 		c = keyfuncs[keymap[c]].ch_on_sos;
-	}
+
 skip_conv:
 	if (scr_capson){
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -54,6 +54,7 @@
 #include "compat.h"
 #include "sos.h"
 #include "screen.h"
+#include "keymap.h"
 #include "trap.h"
 #include "simz80.h"
 
@@ -152,45 +153,28 @@ void	scr_key_backspace(void), scr_key_delete(void),
 	scr_key_redraw(void), scr_key_kill(void), scr_key_tab(void),
 	scr_key_yank(void), scr_key_imode(void), scr_key_clear(void);
 struct keyfunc {
-    char	*funcname;	/* name of function */
-    void	(*func)(void);	/* pointer to function */
+	char	*funcname;	/* name of function */
+	void	(*func)(void);	/* pointer to function */
+	char    ch_on_sos;      /* character code in S-OS */
 };
 typedef struct keyfunc keyfunc_t;
 static keyfunc_t keyfuncs[] = {
-    {"backspace", scr_key_backspace},
-    {"delete", scr_key_delete},
-    {"begin", scr_key_top},
-    {"end", scr_key_end},
-    {"up", scr_key_up},
-    {"down", scr_key_down},
-    {"forward", scr_key_forward},
-    {"back", scr_key_back},
-    {"redraw", scr_key_redraw},
-    {"kill", scr_key_kill},
-    {"tab", scr_key_tab},
-    {"yank", scr_key_yank},
-    {"imode", scr_key_imode},
-    {"clear", scr_key_clear},
-    {NULL, NULL}
-};
-/*
- * convert table to convert from a keyfunc index to a ctrl code in SWORD.
- * SCR_SOS_NUL(0x00) means that SWORD does not have such ctrl codes.
- */
-static char scr_keyfunc_idx2sword[]={
-	SCR_SOS_NUL,    /* backspace */
-	SCR_SOS_NUL,    /* delete */
-	SCR_SOS_NUL,    /* begin */
-	SCR_SOS_NUL,    /* end */
-	SCR_SOS_UP,     /* up */
-	SCR_SOS_DOWN,   /* down */
-	SCR_SOS_RIGHT,  /* forward */
-	SCR_SOS_LEFT,   /* back */
-	SCR_SOS_NUL,    /* redraw */
-	SCR_SOS_NUL,    /* kill */
-	SCR_SOS_NUL,    /* tab */
-	SCR_SOS_NUL,    /* yank */
-	SCR_SOS_CLS     /* clear */
+	{KEYMAP_NAME_BACKSPACE, scr_key_backspace, SCR_SOS_NUL},
+	{KEYMAP_NAME_DELETE, scr_key_delete, SCR_SOS_NUL},
+	{KEYMAP_NAME_BEGIN, scr_key_top, SCR_SOS_NUL},
+	{KEYMAP_NAME_END, scr_key_end, SCR_SOS_NUL},
+	{KEYMAP_NAME_UP, scr_key_up, SCR_SOS_UP},
+	{KEYMAP_NAME_DOWN, scr_key_down, SCR_SOS_DOWN},
+	{KEYMAP_NAME_FWD, scr_key_forward, SCR_SOS_RIGHT},
+	{KEYMAP_NAME_BACK, scr_key_back, SCR_SOS_LEFT},
+	{KEYMAP_NAME_REDRAW, scr_key_redraw, SCR_SOS_NUL},
+	{KEYMAP_NAME_KILL, scr_key_kill, SCR_SOS_NUL},
+	{KEYMAP_NAME_TAB, scr_key_tab, SCR_SOS_NUL},
+	{KEYMAP_NAME_YANK, scr_key_yank, SCR_SOS_NUL},
+	{KEYMAP_NAME_IMODE, scr_key_imode, SCR_SOS_NUL},
+	{KEYMAP_NAME_CLEAR, scr_key_clear, SCR_SOS_NUL},
+	{KEYMAP_NAME_BREAK, NULL, SCR_SOS_BREAK},
+	{NULL, NULL, SCR_SOS_NUL}
 };
 
 /*
@@ -1311,7 +1295,7 @@ scr_conv(char oc){
 		/*
 		 * Convert cursor keys
 		 */
-		c = scr_keyfunc_idx2sword[keymap[c]];
+		c = keyfuncs[keymap[c]].ch_on_sos;
 	}
 skip_conv:
 	if (scr_capson){

--- a/src/trap.c
+++ b/src/trap.c
@@ -1288,8 +1288,6 @@ int sos_rdi(void){
 
     inf = &tapes[ sos_tape_devindex( GetBYTE(SOS_DSK) ) ];
 
-    PutBYTE( SOS_DIRNO, inf->dirno ); /* Restore DIRNO */
-
     key = sos_fcb_common();  /* read key */
 
     if ( key == SCR_SOS_BREAK )
@@ -1298,46 +1296,45 @@ int sos_rdi(void){
     if ( key == SCR_SOS_CR )
 	    goto position_reset;  /* Read position changed */
 
-    /*
-     * Load file information block except for file attribute.
-     */
+    /* Get the next file name on the tape from UNIX direntries or the tape emulation. */
     rc = dio_dopen((char *)ram + EM_FNAME, &attr, &addr, &len, &exaddr,
-	GetBYTE(SOS_DIRNO) );
-
+	inf->dirno );
     if ( rc != 0 )
-	    goto file_not_found;  /* Cancel Read File Control Block */
+	    goto file_not_found;  /* No file found on inf->dirno */
+
+    /* Load the File Information Block (FIB) */
+    rc = dio_ropen((char *)ram +EM_FNAME, &attr, &addr, &len, &exaddr, 1);
+    if ( rc != 0 )
+	    goto inc_dirno; /* Some UNIX files can not be read by S-OS apps. */
 
     /*
      * Fill File Information Block
      */
     PutBYTE(EM_ATTR, attr);
-
     PutWORD(EM_SIZE, len);
     PutWORD(EM_DTADR, addr);
     PutWORD(EM_EXADR, exaddr);
 
-    sos_parsc();            /* Set #SIZE, #DTADR, #EXADR up */
-    PutBYTE(SOS_OPNFG, 1);  /* open file */
+    sos_parsc();  /* Fill SOS_DTADR, SOS_EXADR, SOS_SIZE */
 
-    sos_tropn();            /* open the file */
+inc_dirno:
+    if ( UCHAR_MAX > inf->dirno )
+	    inf->dirno = inf->dirno + 1; /* Inc DIRNO of the device */
+    else
+	    inf->dirno = 0; /* Reach the end of the tape, so rewind it. */
 
-    inf->dirno = GetBYTE(SOS_DIRNO) + 1; /* Inc DIRNO of the device */
-    if ( inf->dirno == 0xff )
-	    goto file_not_found; /* UCHAR_MAX reached */
-
-    PutBYTE(SOS_DIRNO, inf->dirno);  /* Update #DIRNO */
-    inf->retpoi = inf->dirno;        /* Update RETPOI */
+    inf->retpoi = inf->dirno;    /* Update RETPOI */
 
     SETFLAG(C, 0);
 
     return TRAP_NEXT;
 
 file_not_found:
-	PutBYTE(SOS_DIRNO, 0);  /* Reset #DIRNO */
+	inf->dirno = 0;   /* Reset #DIRNO */
 
 position_reset:
 	inf->retpoi = 0;  /* Reset RETPOI */
-	inf->dirno = GetBYTE(SOS_DIRNO);   /* Save DIRNO of the device */
+
 	Sethreg(Z80_AF, SOS_ERROR_NOENT);  /* File not found */
 	SETFLAG(C, 1);   /* Set carry */
 


### PR DESCRIPTION
キーマップにブレークキー(Ctrl-C)の定義を追加し, Ctrl-C以外のキーをブレークキーとして定義可能にした。
これにより, UNIXキーコードからSwordへのキーコード変換時のコントロールキーの扱いを統一した。