### PR TITLE
修正概要: #FSAMEの動作をX1版Swordの実装に合わせるように修正。

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -870,28 +870,6 @@ int sos_fsame(void){
     /*
      * check the buffer pointed by DE register
      */
-    saved_de = Z80_DE;
-
-    /* pass file name which is read by FILE */
-    Z80_DE = EM_NAMEBF;
-    /* parse file name */
-    r = trap_fname(buf, &dsk, GetBYTE(SOS_DSK));
-    Z80_DE = saved_de; /* restore DE */
-    if ( r != 0 )
-	    goto compare_with_de;
-
-    /* compare them */
-    if (memcmp(buf, ram + EM_IBFAD + 1, SOS_FNAMELEN) == 0){
-	    SETFLAG(Z, 1);
-	    goto out;
-    } else {
-	    SETFLAG(Z, 0);
-    }
-
-    /*
-     * Compare with DE register (MACE)
-     */
-compare_with_de:
     r = trap_fname(buf, &dsk, GetBYTE(SOS_DSK));
     if ( r != 0 ){
 


### PR DESCRIPTION
#FSAMEをS-OS Swordの実装に合わせて修正。
仕様と実装の相違点は以下の通り。

- 仕様: #FILEでセットされたファイルネームと、読み込んだファイルネームを比較する。一致すれぱゼロ、不一致ならばノンゼロでリターンする。アトリビュートのチェックも同時に行う。

- 実装:Aレジスタにファイルの属性, DEレジスタにファイル名を格納した文字列(0x0Dにより文字列を終端)の先頭アドレスを指定し, 指定されたファイル名と#IBFADに格納されているFile Information Blockのファイルの属性および名前を比較し, 一致する場合は, ゼロフラグを立てて復帰する。一致しなかった場合は, ゼロフラグ, キャリーフラグをクリアし, Aレジスタに8(File Not Found)を設定して復帰する。

厳密には, DEレジスタが指し示す文字列をFNAMEBFワークエリアにコピーして, Input Output Control System (IOCS)のFile Information Block (FIB)のファイル名と比較する。DEが指し示す先の先頭が空白またはコントロールコードの場合は、無条件にマッチさせ、それ以外の場合は、'.'を空白に置換えた文字列を0x0d(終端文字)が見つかるまで最大16文字まで比較する。
本実装では, DEが指し示す先の先頭が空白またはコントロールコードの場合は、無条件にマッチさせる処理までは未実装(X1版の動作確認中)。
